### PR TITLE
Fix imports and add agent listing helper

### DIFF
--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -1,6 +1,7 @@
 import { streamText } from "ai"
 import { openai } from "@ai-sdk/openai"
-import { voltAgentClient } from "@/lib/voltagent-client"
+// Import VoltAgent client utilities
+import * as voltAgentClient from "@/lib/mcp-client"
 
 export async function POST(req: Request) {
   try {

--- a/app/api/crypto/route.ts
+++ b/app/api/crypto/route.ts
@@ -5,7 +5,7 @@ import {
   getMarketSummary,
   testVoltAgentConnection,
   getAvailableAgents,
-} from "@/lib/voltagent-client"
+} from "@/lib/mcp-client"
 
 export async function POST(request: NextRequest) {
   try {

--- a/lib/mcp-client.ts
+++ b/lib/mcp-client.ts
@@ -219,6 +219,38 @@ export async function getMarketSummary(): Promise<MCPResponse> {
   }
 }
 
+// Retrieve list of available agents from VoltAgent
+export async function getAvailableAgents(): Promise<MCPResponse> {
+  try {
+    const result = await callVoltAgentTool("get_agents", {})
+
+    if (result && result.success !== false) {
+      return { success: true, data: result }
+    }
+
+    // Fallback mock data if VoltAgent does not respond
+    return {
+      success: true,
+      data: {
+        data: [
+          {
+            id: "crypto-mcp",
+            model: "gpt-4o-mini",
+            status: "unknown",
+            tools: ["get_crypto_price", "get_market_summary"],
+          },
+        ],
+      },
+    }
+  } catch (error) {
+    console.error("Get agents error:", error)
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : "Unknown error occurred",
+    }
+  }
+}
+
 // Test VoltAgent connection
 export async function testVoltAgentConnection(): Promise<boolean> {
   try {


### PR DESCRIPTION
## Summary
- fix usage of missing `voltagent-client` by importing utilities from `lib/mcp-client`
- add `getAvailableAgents` helper with fallback data for VoltAgent

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: requires ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_688c5bef0c10832ebc7570686ee44c44